### PR TITLE
Minor updates to web app

### DIFF
--- a/tools/webBLE-fwUpload/dfu.html
+++ b/tools/webBLE-fwUpload/dfu.html
@@ -98,6 +98,10 @@
         </div>
       </div>
 
+      <br>
+
+      <p id="endPrint"></p>
+
     </div>
     <br><hr><br>
 
@@ -329,6 +333,9 @@ function handleAck(value) {
   }
   if (updateIndex == iterations) {
     console.log('firmware sent');
+    elem.style.width = 100 + "%";
+    elem.style.backgroundColor = "#18b31d";
+    document.getElementById("endPrint").innerHTML = "Fw upload completed!";
     return;
   }
   update(updateIndex);


### PR DESCRIPTION
### Description
Success (green) and fail (red) colors have been added for the Connect button to visually display BLE connection result.
When upload completes, the progress bar turns green and a message is shown.
<!-- 
    
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Breaking change

