### PR TITLE
I2C and BLE Selective begin 

### DIFF
--- a/Arduino_BHY2/examples/App/App.ino
+++ b/Arduino_BHY2/examples/App/App.ino
@@ -4,8 +4,11 @@
  * Here, nicla just reacts to external stimuli coming from
  * the eslov port or through BLE 
  * 
- * NOTE: if Nicla is used as a Shield on top of a MKR board,
- * please use BHY2.begin(NICLA_AS_SHIELD)
+ * NOTE: Remember to choose your Nicla configuration! 
+ * If Nicla is used as a Shield, provide the NICLA_AS_SHIELD parameter.
+ * If you want to enable just one between I2C and BLE,
+ * use NICLA_I2C or NICLA_BLE parameters.
+ *
 */
 
 #include "Arduino.h"

--- a/Arduino_BHY2/src/Arduino_BHY2.h
+++ b/Arduino_BHY2/src/Arduino_BHY2.h
@@ -15,8 +15,27 @@
 #include "sensors/SensorID.h"
 
 enum NiclaWiring {
-  NICLA_VIA_ESLOV = 0,
-  NICLA_AS_SHIELD
+  NICLA_VIA_ESLOV = 0x10,
+  NICLA_AS_SHIELD = 0x20
+};
+
+enum NiclaConfig {
+  NICLA_I2C = 0x1,
+  NICLA_BLE = 0x2,
+  NICLA_BLE_AND_I2C = NICLA_I2C | NICLA_BLE
+};
+
+class NiclaSettings {
+public:
+  NiclaSettings(uint8_t conf1 = 0, uint8_t conf2 = 0, uint8_t conf3 = 0, uint8_t conf4 = 0) {
+    conf = conf1 | conf2 | conf3 | conf4;
+  }
+
+  uint8_t getConfiguration() const {
+    return conf;
+  }
+private:
+  uint8_t conf = 0;
 };
 
 class Arduino_BHY2 {
@@ -25,7 +44,8 @@ public:
   virtual ~Arduino_BHY2();
 
   // Necessary API. Update function should be continuously polled 
-  bool begin(NiclaWiring niclaConnection = NICLA_VIA_ESLOV);
+  bool begin(NiclaConfig config = NICLA_BLE_AND_I2C, NiclaWiring niclaConnection = NICLA_VIA_ESLOV);
+  bool begin(NiclaSettings& settings);
   void update(); // remove this to enforce a sleep
   void update(unsigned long ms); // Update and then sleep
   void delay(unsigned long ms); // to be used instead of arduino delay()
@@ -58,6 +78,8 @@ private:
   bool _eslovActive;
 
   PinName _eslovIntPin;
+
+  NiclaConfig _niclaConfig;
 };
 
 extern Arduino_BHY2 BHY2;

--- a/Arduino_BHY2_HOST/src/EslovHandler.cpp
+++ b/Arduino_BHY2_HOST/src/EslovHandler.cpp
@@ -140,14 +140,23 @@ void EslovHandler::update()
 
 void EslovHandler::writeDfuPacket(uint8_t *data, uint8_t length)
 {
-  Wire.beginTransmission(ESLOV_DEFAULT_ADDRESS);
-  int ret = Wire.write(data, length);
-  if (_debug){
-    _debug->print("Write returned: ");
-    _debug->print(ret);
-    _debug->println();
+  uint8_t attempts = 0;
+  uint8_t bytesToWrite = length;
+  while(bytesToWrite && (attempts < 3)) {
+    Wire.beginTransmission(ESLOV_DEFAULT_ADDRESS);
+    int ret = Wire.write(data, length);
+    if (_debug){
+      _debug->print("Write returned: ");
+      _debug->print(ret);
+      _debug->println();
+    }
+    /*
+    endTransmission returns 0 if the number of bytes written
+    *  is equal to the total length. Otherwise, a positive number is returned
+    */
+    bytesToWrite = Wire.endTransmission(true);
+    attempts++;
   }
-  Wire.endTransmission(true);
   if (*(data+1)) {
     //Last packet
     pinMode(LED_BUILTIN, OUTPUT);


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This PR allows to let the user select what to use by the time the `BHY2.begin()` function is called. This allows to avoid starting I2C or BLE threads if they are not needed.

Two options have been provided to configure the settings:

SOLUTION N.1:
`bool begin(NiclaConfig config = NICLA_BLE_AND_I2C, NiclaWiring niclaConnection = NICLA_VIA_ESLOV);`

Possible configurations:
- Both I2C and BLE enabled, Nicla connected via Eslov cable: `BHY2.begin();`
- Both I2C and BLE enabled, Nicla connected as a Shield: `BHY2.begin(NICLA_BLE_AND_I2C, NICLA_AS_SHIELD);`
- Only I2C enabled, Nicla connected via Eslov cable: `BHY2.begin(NICLA_I2C);`
- Only I2C enabled, Nicla connected as a Shield: `BHY2.begin(NICLA_I2C, NICLA_AS_SHIELD);`
- Only BLE enabled: `BHY2.begin(NICLA_BLE);`


SOLUTION N.2:
Use **NiclaSettings** class to set Nicla configuration. This method is similar to the SPISettings one, used to set SPI parameters.
`bool begin(NiclaSettings& settings);`

Possible configurations:
- Both I2C and BLE enabled, Nicla connected via Eslov cable: `NiclaSettings settings(NICLA_I2C, NICLA_BLE, NICLA_VIA_ESLOV, 0);`
- Both I2C and BLE enabled, Nicla connected as a Shield: `NiclaSettings settings(NICLA_I2C, NICLA_BLE, 0, NICLA_AS_SHIELD);`
- Only I2C enabled, Nicla connected via Eslov cable: `NiclaSettings settings(NICLA_I2C, 0, NICLA_VIA_ESLOV, 0);`
- Only I2C enabled, Nicla connected as a Shield: `NiclaSettings settings(NICLA_I2C, 0, 0, NICLA_AS_SHIELD);`
- Only BLE enabled: `NiclaSettings settings(0, NICLA_BLE, 0, 0);`
And `BHY2.begin(settings);`


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

