### PR TITLE
Fix quaternion data parsing

### DIFF
--- a/Arduino_BHY2/examples/Standalone/Standalone.ino
+++ b/Arduino_BHY2/examples/Standalone/Standalone.ino
@@ -12,6 +12,7 @@ SensorXYZ accel(SENSOR_ID_ACC);
 SensorXYZ gyro(SENSOR_ID_GYRO);
 Sensor temp(SENSOR_ID_TEMP);
 Sensor gas(SENSOR_ID_GAS);
+SensorQuaternion rotation(SENSOR_ID_RV);
 
 void setup()
 {
@@ -24,6 +25,7 @@ void setup()
   gyro.begin();
   temp.begin();
   gas.begin();
+  rotation.begin();
 }
 
 void loop()
@@ -40,5 +42,6 @@ void loop()
     Serial.println(String("gyroscope: ") + gyro.toString());
     Serial.println(String("temperature: ") + String(temp.value(),3));
     Serial.println(String("gas: ") + String(gas.value(),3));
+    Serial.println(String("rotation: ") + rotation.toString());
   }
 }

--- a/Arduino_BHY2/src/sensors/DataParser.cpp
+++ b/Arduino_BHY2/src/sensors/DataParser.cpp
@@ -16,12 +16,12 @@ void DataParser::parseEuler(SensorDataPacket& data, DataOrientation& vector) {
   parseEuler(data, vector, 1.f);
 }
 
-void DataParser::parseQuaternion(SensorDataPacket& data, DataQuaternion& vector) {
-  vector.x = data.getInt16(0);
-  vector.y = data.getInt16(2);
-  vector.z = data.getInt16(4);
-  vector.w = data.getInt16(6);
-  vector.accuracy = data.getUint16(8);
+void DataParser::parseQuaternion(SensorDataPacket& data, DataQuaternion& vector, float scaleFactor) {
+  vector.x = data.getInt16(0) * scaleFactor;
+  vector.y = data.getInt16(2) * scaleFactor;
+  vector.z = data.getInt16(4) * scaleFactor;
+  vector.w = data.getInt16(6) * scaleFactor;
+  vector.accuracy = data.getUint16(8) * scaleFactor;
 }
 
 void DataParser::parseBSEC(SensorDataPacket& data, DataBSEC& vector) {

--- a/Arduino_BHY2/src/sensors/DataParser.h
+++ b/Arduino_BHY2/src/sensors/DataParser.h
@@ -30,18 +30,18 @@ struct DataOrientation {
 };
 
 struct DataQuaternion {
-  int16_t x;
-  int16_t y;
-  int16_t z;
-  int16_t w;
-  uint16_t accuracy;
+  float x;
+  float y;
+  float z;
+  float w;
+  float accuracy;
 
   String toString() {
-    return (String)("Quaternion values - X: " + String(x)
-                    + "   Y: " + String(y)
-                    + "   Z: " + String(z)
-                    + "   W: " + String(w)
-                    + "   Accuracy: " + String(accuracy)
+    return (String)("Quaternion values - X: " + String(x, 3)
+                    + "   Y: " + String(y, 3)
+                    + "   Z: " + String(z, 3)
+                    + "   W: " + String(w, 3)
+                    + "   Accuracy: " + String(accuracy, 3)
                     + "\n");
   }
 };
@@ -75,7 +75,7 @@ public:
   static void parse3DVector(SensorDataPacket& data, DataXYZ& vector);
   static void parseEuler(SensorDataPacket& data, DataOrientation& vector);
   static void parseEuler(SensorDataPacket& data, DataOrientation& vector, float scaleFactor);
-  static void parseQuaternion(SensorDataPacket& data, DataQuaternion& vector);
+  static void parseQuaternion(SensorDataPacket& data, DataQuaternion& vector, float scaleFactor);
   static void parseBSEC(SensorDataPacket& data, DataBSEC& vector);
   static void parseBSECLegacy(SensorDataPacket& data, DataBSEC& vector);
   static void parseData(SensorDataPacket& data, float& value, float scaleFactor, SensorPayload format);

--- a/Arduino_BHY2/src/sensors/SensorQuaternion.h
+++ b/Arduino_BHY2/src/sensors/SensorQuaternion.h
@@ -6,28 +6,37 @@
 class SensorQuaternion : public SensorClass {
 public:
   SensorQuaternion() {} 
-  SensorQuaternion(uint8_t id) : SensorClass(id), _data() {}
+  SensorQuaternion(uint8_t id) : SensorClass(id), _data(), _factor(0.000061035) {}
 
-  int16_t x() 
+  float x() 
   { 
     return _data.x; 
   }
-  int16_t y()
+  float y()
   {
     return _data.y;
   }
-  int16_t z()
+  float z()
   {
     return _data.z;
   }
-  int16_t w()
+  float w()
   {
     return _data.w;
+  }
+  float accuracy()
+  {
+    return _data.accuracy;
+  }
+
+  float getFactor()
+  {
+    return _factor;
   }
 
   void setData(SensorDataPacket &data)
   {
-    DataParser::parseQuaternion(data, _data);
+    DataParser::parseQuaternion(data, _data, _factor);
   }
 
   String toString()
@@ -36,6 +45,7 @@ public:
   }
 
 private:
+  float _factor;
   DataQuaternion _data;
 };
 

--- a/Arduino_BHY2Host/src/sensors/DataParser.cpp
+++ b/Arduino_BHY2Host/src/sensors/DataParser.cpp
@@ -16,12 +16,12 @@ void DataParser::parseEuler(SensorDataPacket& data, DataOrientation& vector) {
   parseEuler(data, vector, 1.f);
 }
 
-void DataParser::parseQuaternion(SensorDataPacket& data, DataQuaternion& vector) {
-  vector.x = data.getInt16(0);
-  vector.y = data.getInt16(2);
-  vector.z = data.getInt16(4);
-  vector.w = data.getInt16(6);
-  vector.accuracy = data.getUint16(8);
+void DataParser::parseQuaternion(SensorDataPacket& data, DataQuaternion& vector, float scaleFactor) {
+  vector.x = data.getInt16(0) * scaleFactor;
+  vector.y = data.getInt16(2) * scaleFactor;
+  vector.z = data.getInt16(4) * scaleFactor;
+  vector.w = data.getInt16(6) * scaleFactor;
+  vector.accuracy = data.getUint16(8) * scaleFactor;
 }
 
 void DataParser::parseData(SensorDataPacket& data, float& value, float scaleFactor, SensorPayload format) {

--- a/Arduino_BHY2Host/src/sensors/DataParser.h
+++ b/Arduino_BHY2Host/src/sensors/DataParser.h
@@ -30,18 +30,18 @@ struct DataOrientation {
 };
 
 struct DataQuaternion {
-  int16_t x;
-  int16_t y;
-  int16_t z;
-  int16_t w;
-  uint16_t accuracy;
+  float x;
+  float y;
+  float z;
+  float w;
+  float accuracy;
 
   String toString() {
-    return (String)("Quaternion values - X: " + String(x)
-                    + "   Y: " + String(y)
-                    + "   Z: " + String(z) 
-                    + "   W: " + String(w) 
-                    + "   Accuracy: " + String(accuracy) 
+    return (String)("Quaternion values - X: " + String(x, 3)
+                    + "   Y: " + String(y, 3)
+                    + "   Z: " + String(z, 3) 
+                    + "   W: " + String(w, 3) 
+                    + "   Accuracy: " + String(accuracy, 3) 
                     + "\n");
   }
 };
@@ -51,7 +51,7 @@ public:
   static void parse3DVector(SensorDataPacket& data, DataXYZ& vector);
   static void parseEuler(SensorDataPacket& data, DataOrientation& vector);
   static void parseEuler(SensorDataPacket& data, DataOrientation& vector, float scaleFactor);
-  static void parseQuaternion(SensorDataPacket& data, DataQuaternion& vector);
+  static void parseQuaternion(SensorDataPacket& data, DataQuaternion& vector, float scaleFactor);
   static void parseData(SensorDataPacket& data, float& value, float scaleFactor, SensorPayload format);
   static void parseActivity(SensorDataPacket& data, uint16_t value);
 };

--- a/Arduino_BHY2Host/src/sensors/SensorQuaternion.h
+++ b/Arduino_BHY2Host/src/sensors/SensorQuaternion.h
@@ -6,28 +6,37 @@
 class SensorQuaternion : public SensorClass {
 public:
   SensorQuaternion() {} 
-  SensorQuaternion(uint8_t id) : SensorClass(id), _data() {}
+  SensorQuaternion(uint8_t id) : SensorClass(id), _data(), _factor(0.000061035) {}
 
-  int16_t x() 
+  float x() 
   { 
     return _data.x; 
   }
-  int16_t y()
+  float y()
   {
     return _data.y;
   }
-  int16_t z()
+  float z()
   {
     return _data.z;
   }
-  int16_t w()
+  float w()
   {
     return _data.w;
+  }
+  float accuracy()
+  {
+    return _data.accuracy;
+  }
+
+  float getFactor()
+  {
+    return _factor;
   }
 
   void setData(SensorDataPacket &data)
   {
-    DataParser::parseQuaternion(data, _data);
+    DataParser::parseQuaternion(data, _data, _factor);
   }
 
   String toString()
@@ -36,6 +45,7 @@ public:
   }
 
 private:
+  float _factor;
   DataQuaternion _data;
 };
 


### PR DESCRIPTION
### Description
This PR should solve issue #40. Parsing of quaternion data was wrong in the BHY2 libraries, but correct in the [webApp](https://github.com/arduino/nicla-sense-me-fw/blob/3a17fe1f21cc5ba15fe2b8b224ed907a5d6c1e14/tools/bhy-controller/src/webserver/parse-scheme.json#L7-L14) and go tool.
Now both BHY2 libraries parse quaternion data as float numbers and with scale factor `0.000061035`.
`float accuracy()` and `float getFactor()` functions have been added to the `SensorQuaternion` class.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

