### PR TITLE
Nicla fw optimizations

### DIFF
--- a/Arduino_BHY2/src/Arduino_BHY2.cpp
+++ b/Arduino_BHY2/src/Arduino_BHY2.cpp
@@ -14,7 +14,6 @@ Arduino_BHY2::Arduino_BHY2() :
   _debug(NULL),
   _pingTime(0),
   _timeout(120000),
-  _eslovActive(false),
   _startTime(0),
   _eslovIntPin(PIN_ESLOV_INT),
   _niclaConfig(NICLA_BLE_AND_I2C)
@@ -35,22 +34,6 @@ void Arduino_BHY2::pingI2C() {
   }
 }
 
-void Arduino_BHY2::checkEslovInt() {
-  if (!digitalRead(_eslovIntPin)) {
-    //Wait for MKR to clear Eslov Int pin
-    while(!digitalRead(_eslovIntPin)) {}
-    if (_debug) _debug->println("MKR released Eslov Int pin");
-
-    //Change mode for Eslov Int pin
-    //Eslov Int Pin will be used to synchronize Dfu via Eslov
-    pinMode(_eslovIntPin, OUTPUT);
-
-    eslovHandler.begin();
-    //Eslov has been activated
-    _eslovActive = true;
-  }
-}
-
 void Arduino_BHY2::setLDOTimeout(int time) {
   _timeout = time;
 }
@@ -64,20 +47,27 @@ bool Arduino_BHY2::begin(NiclaConfig config, NiclaWiring niclaConnection)
     eslovHandler.niclaAsShield();
   }
 
-  pinMode(_eslovIntPin, INPUT);
   nicla::begin();
   _startTime = millis();
   nicla::enable3V3LDO();
-  Wire1.setClock(500000);
   _pingTime = millis();
   if (!sensortec.begin()) {
     return false;
   }
   if (_niclaConfig & NICLA_BLE) {
+    //Start BLE Handler
     if (!bleHandler.begin()) {
       return false;
     }
   }
+  if (_niclaConfig & NICLA_I2C) {
+    //Start Eslov Handler
+    pinMode(_eslovIntPin, OUTPUT);
+    if (!eslovHandler.begin()) {
+      return false;
+    }
+  }
+  //Start DFU Manager
   if (!dfuManager.begin()) {
     return false;
   }
@@ -112,12 +102,6 @@ bool Arduino_BHY2::begin(NiclaSettings& settings)
 void Arduino_BHY2::update()
 {
   pingI2C();
-
-  if (_niclaConfig & NICLA_I2C) {
-    if (!_eslovActive) {
-      checkEslovInt();
-    }
-  }
 
   sensortec.update();
   if (_niclaConfig & NICLA_BLE) {

--- a/Arduino_BHY2/src/Arduino_BHY2.h
+++ b/Arduino_BHY2/src/Arduino_BHY2.h
@@ -63,7 +63,6 @@ public:
   void parse(SensorDataPacket& data, DataOrientation& vector);
   void parse(SensorDataPacket& data, DataOrientation& vector, float scaleFactor);
 
-  void checkEslovInt();
   void setLDOTimeout(int time);
 
   void debug(Stream &stream);
@@ -75,7 +74,6 @@ private:
   int _pingTime;
   int _timeout;
   int _startTime;
-  bool _eslovActive;
 
   PinName _eslovIntPin;
 

--- a/Arduino_BHY2/src/EslovHandler.cpp
+++ b/Arduino_BHY2/src/EslovHandler.cpp
@@ -56,7 +56,18 @@ void EslovHandler::requestEvent()
 
   if (_debug) {
     _debug->print("Wire Request event. State: ");
-    _debug->println(_state);
+    if (_state == ESLOV_AVAILABLE_SENSOR_STATE) {
+      _debug->println("ESLOV_AVAILABLE_SENSOR_STATE");
+    }
+    else if (_state == ESLOV_READ_SENSOR_STATE) {
+      _debug->println("ESLOV_READ_SENSOR_STATE");
+    }
+    else if (_state == ESLOV_SENSOR_ACK_STATE) {
+      _debug->println("ESLOV_SENSOR_ACK_STATE");
+    }
+    else {
+      _debug->println(_state);
+    }
   }
 
   if (_state == ESLOV_AVAILABLE_SENSOR_STATE) {
@@ -110,6 +121,10 @@ void EslovHandler::receiveEvent(int length)
     // Check if packet is complete depending on its opcode
     if (_rxBuffer[0] == ESLOV_DFU_EXTERNAL_OPCODE) {
       if (_rxIndex == sizeof(DFUPacket) + 1) {
+        if (_debug) {
+          _debug->print("Opcode: ");
+          _debug->println("ESLOV_DFU_EXTERNAL_OPCODE");
+        }
         dfuManager.processPacket(eslovDFU, DFU_EXTERNAL, &_rxBuffer[1]);
 
         dump();
@@ -126,6 +141,10 @@ void EslovHandler::receiveEvent(int length)
 
     } else if (_rxBuffer[0] == ESLOV_DFU_INTERNAL_OPCODE) {
       if (_rxIndex == sizeof(DFUPacket) + 1) {
+        if (_debug) {
+          _debug->print("Opcode: ");
+          _debug->println("ESLOV_DFU_INTERNAL_OPCODE");
+        }
         dfuManager.processPacket(eslovDFU, DFU_INTERNAL, &_rxBuffer[1]);
 
         dump();
@@ -142,6 +161,10 @@ void EslovHandler::receiveEvent(int length)
 
     } else if (_rxBuffer[0] == ESLOV_SENSOR_CONFIG_OPCODE) {
       if (_rxIndex == sizeof(SensorConfigurationPacket) + 1) {
+        if (_debug) {
+          _debug->print("Opcode: ");
+          _debug->println("ESLOV_SENSOR_CONFIG_OPCODE");
+        }
         SensorConfigurationPacket *config = (SensorConfigurationPacket*)&_rxBuffer[1];
         sensortec.configureSensor(*config);
 
@@ -156,6 +179,10 @@ void EslovHandler::receiveEvent(int length)
     } else if (_rxBuffer[0] == ESLOV_SENSOR_STATE_OPCODE) {
       if (_rxIndex == 2) {
         _state = (EslovState)_rxBuffer[1];
+        if (_debug) {
+          _debug->print("Opcode: ");
+          _debug->println("ESLOV_SENSOR_STATE_OPCODE");
+        }
 
         dump();
         _rxIndex = 0;
@@ -191,8 +218,10 @@ void EslovHandler::debug(Stream &stream)
 void EslovHandler::dump() 
 {
   if (_debug) {
-    _debug->print("received: ");
+    _debug->print("received:   ");
+    _debug->print("size: ");
     _debug->println(_rxIndex);
+    _debug->print("   packet: ");
     for (int i = 0; i < _rxIndex; i++) {
       _debug->print(_rxBuffer[i], HEX);
       _debug->print(", ");

--- a/Arduino_BHY2Host/examples/Nicla_IoT_Bridge/Nicla_IoT_Bridge.ino
+++ b/Arduino_BHY2Host/examples/Nicla_IoT_Bridge/Nicla_IoT_Bridge.ino
@@ -60,10 +60,3 @@ void loop() {
   
   ArduinoCloud.update();
 }
-
-void onTempChange() {
-}
-
-
-void onSecondsChange() {
-}

--- a/Arduino_BHY2Host/examples/Nicla_IoT_Bridge/thingProperties.h
+++ b/Arduino_BHY2Host/examples/Nicla_IoT_Bridge/thingProperties.h
@@ -8,17 +8,14 @@ const char THING_ID[] = "";
 const char SSID[]     = SECRET_SSID;    // Network SSID (name)
 const char PASS[]     = SECRET_PASS;    // Network password (use for WPA, or use as key for WEP)
 
-void onTempChange();
-void onSecondsChange();
-
 float temp;
 int seconds;
 
 void initProperties(){
 
   ArduinoCloud.setThingId(THING_ID);
-  ArduinoCloud.addProperty(temp, READWRITE, ON_CHANGE, onTempChange);
-  ArduinoCloud.addProperty(seconds, READWRITE, ON_CHANGE, onSecondsChange);
+  ArduinoCloud.addProperty(temp, READ, 1 * SECONDS, NULL);
+  ArduinoCloud.addProperty(seconds, READ, 1 * SECONDS, NULL);
 
 }
 

--- a/Arduino_BHY2Host/src/Arduino_BHY2Host.cpp
+++ b/Arduino_BHY2Host/src/Arduino_BHY2Host.cpp
@@ -48,6 +48,7 @@ void Arduino_BHY2Host::update()
       eslovHandler.update();
     } else {
       uint8_t available = availableSensorData();
+      delay(1);
       for (int i = 0; i < available; i++) {
         SensorDataPacket data;
         readSensorData(data);

--- a/Arduino_BHY2Host/src/EslovHandler.cpp
+++ b/Arduino_BHY2Host/src/EslovHandler.cpp
@@ -20,9 +20,7 @@ EslovHandler::~EslovHandler()
 
 bool EslovHandler::begin(bool passthrough)
 {
-  pinMode(_eslovIntPin, OUTPUT);
-  digitalWrite(_eslovIntPin, LOW);
-
+  pinMode(_eslovIntPin, INPUT);
   Wire.begin();
   Wire.setClock(400000);
   if (passthrough) {
@@ -40,15 +38,11 @@ void EslovHandler::update()
     if (_rxBuffer[0] == HOST_DFU_EXTERNAL_OPCODE || _rxBuffer[0] == HOST_DFU_INTERNAL_OPCODE) {
       if (_rxIndex == sizeof(DFUPacket) + 1) {
 
-        toggleEslovIntPin();
-
         if (!_dfuLedOn) {
           pinMode(LED_BUILTIN, OUTPUT);
           digitalWrite(LED_BUILTIN, HIGH);
           flushWire();
         }
-
-        pinMode(_eslovIntPin, INPUT);
 
         //Wait for Nicla to set _eslovIntPin HIGH, meaning that is ready to receive
         while(!digitalRead(_eslovIntPin)) {
@@ -104,7 +98,6 @@ void EslovHandler::update()
     } else if (_rxBuffer[0] == HOST_CONFIG_SENSOR_OPCODE) {
       if (_rxIndex == sizeof(SensorConfigurationPacket) + 1) {
 
-        toggleEslovIntPin();
         SensorConfigurationPacket* config = (SensorConfigurationPacket*)&_rxBuffer[1];
         if (_debug) {
           _debug->print("received config: ");
@@ -228,28 +221,6 @@ bool EslovHandler::requestSensorData(SensorDataPacket &sData)
     data[i] = Wire.read();
   }
   return true;
-}
-
-void EslovHandler::toggleEslovIntPin()
-{
-  if (!_intPinAsserted) {
-    // Indicates eslov presence
-    pinMode(_eslovIntPin, OUTPUT);
-    digitalWrite(_eslovIntPin, LOW);
-    _intPinAsserted = true;
-    if (_debug) {
-      _debug->println("Eslov int LOW");
-    }
-    //Use 1 sec delay to let Nicla see the LOW pin and enable Eslov
-    delay(500);
-
-    digitalWrite(_eslovIntPin, HIGH);
-    _intPinCleared = true;
-    if (_debug) {
-      _debug->println("Eslov int pin cleared");
-    }
-    delay(500);
-  }
 }
 
 void EslovHandler::niclaAsShield()

--- a/Arduino_BHY2Host/src/EslovHandler.cpp
+++ b/Arduino_BHY2Host/src/EslovHandler.cpp
@@ -1,6 +1,6 @@
 #include "EslovHandler.h"
 
-#define ESLOV_DELAY (10)
+#define ESLOV_DELAY (1)
 
 EslovHandler::EslovHandler() :
   _rxIndex(0),
@@ -70,8 +70,6 @@ void EslovHandler::update()
         dump();
 
         _rxIndex = 0;
-
-        delay(ESLOV_DELAY);
       
         Serial.write(ack);
       }
@@ -86,9 +84,15 @@ void EslovHandler::update()
 
       SensorDataPacket sensorData;
       while (availableData) {
-        //delay(ESLOV_DELAY);
         requestSensorData(sensorData);
-        delay(ESLOV_DELAY);
+        /*
+        This delay is needed because the synchronization mechanism over the Eslov Int Pin
+        may not apply for the requests from the host board to Nicla.
+        It may happen that the onRequest callback on Nicla side is serviced after a certain delay.
+        We need to add this delay of 10ms to avoid that a second request is issued before
+        the first one is handled.
+        */
+        delay(10);
         Serial.write((uint8_t*)&sensorData, sizeof(sensorData));
         availableData--;
       }
@@ -161,31 +165,28 @@ void EslovHandler::writeDfuPacket(uint8_t *data, uint8_t length)
 
 void EslovHandler::writeStateChange(EslovState state)
 {
-  delay(ESLOV_DELAY);
   while(!digitalRead(_eslovIntPin)) {}
   uint8_t packet[2] = {ESLOV_SENSOR_STATE_OPCODE, state};
   Wire.beginTransmission(ESLOV_DEFAULT_ADDRESS);
   Wire.write((uint8_t*)packet, sizeof(packet));
   Wire.endTransmission();
-  delay(ESLOV_DELAY);
   _eslovState = state;
 }
 
 void EslovHandler::writeConfigPacket(SensorConfigurationPacket& config)
 {
-  delay(ESLOV_DELAY);
+  while(!digitalRead(_eslovIntPin)) {}
   uint8_t packet[sizeof(SensorConfigurationPacket) + 1]; 
   packet[0] = ESLOV_SENSOR_CONFIG_OPCODE;
   memcpy(&packet[1], &config, sizeof(SensorConfigurationPacket));
   Wire.beginTransmission(ESLOV_DEFAULT_ADDRESS);
   Wire.write(packet, sizeof(SensorConfigurationPacket) + 1);
   Wire.endTransmission();
-  delay(ESLOV_DELAY);
 }
 
 uint8_t EslovHandler::requestPacketAck()
-{ 
-  delay(ESLOV_DELAY);
+{
+  while(!digitalRead(_eslovIntPin)) {}
   uint8_t ret = 0;
   while(!ret) {
     ret = Wire.requestFrom(ESLOV_DEFAULT_ADDRESS, 1);
@@ -204,15 +205,14 @@ uint8_t EslovHandler::requestAvailableData()
   uint8_t ret = Wire.requestFrom(ESLOV_DEFAULT_ADDRESS, 1);
   if (!ret) return 0;
   return Wire.read();
-  delay(ESLOV_DELAY);
 }
 
 bool EslovHandler::requestSensorData(SensorDataPacket &sData)
 {
   if (_eslovState != ESLOV_READ_SENSOR_STATE) {
     writeStateChange(ESLOV_READ_SENSOR_STATE);
-    while(!digitalRead(_eslovIntPin)) {}
   }
+  while(!digitalRead(_eslovIntPin)) {}
   uint8_t ret = Wire.requestFrom(ESLOV_DEFAULT_ADDRESS, sizeof(SensorDataPacket));
   if (!ret) return false;
 

--- a/Arduino_BHY2Host/src/EslovHandler.h
+++ b/Arduino_BHY2Host/src/EslovHandler.h
@@ -49,7 +49,6 @@ public:
   uint8_t requestPacketAck();
   uint8_t requestAvailableData() ;
   bool requestSensorData(SensorDataPacket &sData);
-  void toggleEslovIntPin();
 
 protected:
   void niclaAsShield();

--- a/Arduino_BHY2Host/src/sensors/SensorClass.cpp
+++ b/Arduino_BHY2Host/src/sensors/SensorClass.cpp
@@ -38,7 +38,6 @@ void SensorClass::configure(float rate, uint32_t latency)
   if (BHY2Host.getNiclaConnection() == NICLA_VIA_BLE) {
     BHY2Host.configureSensor(config);
   } else {
-    eslovHandler.toggleEslovIntPin();
     uint8_t ack = 0;
     while(ack != 15) {
       BHY2Host.configureSensor(config);

--- a/bootloader/src/main.cpp
+++ b/bootloader/src/main.cpp
@@ -78,17 +78,17 @@ int mountFileSystem()
 int check_signature(FILE *file, long file_len)
 {
     void *signature = NULL;
-    char buffer[128];
-    int nChunks = ceil(file_len/128);
+    char buffer[512];
+    int nChunks = ceil(file_len/512);
 
     for (int j = 0; j < sizeof("NICLA"); j++) {
 
         for (int i = 0; i < nChunks; i++) {
-            int file_ptr = j + i*128;
+            int file_ptr = j + i*512;
             fseek(file, 0, SEEK_SET);
             fseek(file, file_ptr, SEEK_SET);
-            fread(buffer, 1, 128, file);
-            signature = memmem(buffer, 128, "NICLA", sizeof("NICLA"));
+            fread(buffer, 1, 512, file);
+            signature = memmem(buffer, 512, "NICLA", sizeof("NICLA"));
 
             if (signature != NULL) {
                 DEBUG_PRINTF("Signature check PASSED \r\n");


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This PR introduces some firmware improvements and optimizations that aim at simplifying the code and improving its stability, in particular when using the Host board + Nicla Sense setup.

The main change is about the usage of the Eslov Int Pin. In the current released libraries, this pin is used not only for synchronization, but also to signal Nicla board that communication over the Eslov interface is going to start. There is, indeed, a change of pinMode for the ESLOV_INT_PIN. The current used mechanism is the following:
1. At start up the ESLOV_INT_PIN is used as OUTPUT of the Host board and INPUT of Nicla Sense. 
2. This pin is toggled by the Host board to let Nicla know that communication over Eslov interface is going to start. 
3. Then the pinMode is reversed and ESLOV_INT_PIN is driven by Nicla to synchronize communication over Eslov.

This complex mechanism was required because there was not enough stack space to start both Eslov and BLE interface and run their threads. 
Now, thanks to the change introduced by [PR #375 in ArduinoCore-mbed](https://github.com/arduino/ArduinoCore-mbed/pull/375) which frees the slave thread stack size when `Wire.end()` is called, both Eslov interface and BLE can be activated within the `BHY2.begin()` function. Then, one of the two will be eventually disabled.
**NOTE: this PR cannot be merged before a new release of Nicla core containing the mentioned patch is done!**

Other introduced changes:
- speed-up in firmware validity check inside the Bootloader
- reduction or removal of not needed delays. 
About this point, some of them are still needed, in particular when issuing a Wire request from the Host board to Nicla Sense. The synchronization mechanism over ESLOV_INT_PIN ( `while(!digitalRead(_eslovIntPin)) {}` ) may not be enough here, since the callback on Nicla side may be serviced after a certain delay. Therefore we need to add a delay to avoid that a second request is issued before the first one is handled. A more efficient solution here would have been to start a thread that checks the ESLOV_INT_PIN activity, but this could be done only for Portenta and not for the MKR family.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

