### PR TITLE
Add methods for reading sensor configuration

### DIFF
--- a/Arduino_BHY2/examples/ReadSensorConfiguration/ReadSensorConfiguration.ino
+++ b/Arduino_BHY2/examples/ReadSensorConfiguration/ReadSensorConfiguration.ino
@@ -1,0 +1,59 @@
+/*
+   This sketch shows how to retrieve actual configuration
+   - sample rate and latency – from sensors.
+*/
+
+#include "Arduino.h"
+#include "Arduino_BHY2.h"
+
+SensorXYZ accel(SENSOR_ID_ACC);
+SensorXYZ gyro(SENSOR_ID_GYRO);
+Sensor temp(SENSOR_ID_TEMP);
+Sensor gas(SENSOR_ID_GAS);
+SensorQuaternion rotation(SENSOR_ID_RV);
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial);
+
+  BHY2.begin();
+
+  accel.begin();
+  gyro.begin();
+  temp.begin();
+  gas.begin();
+  rotation.begin();
+
+}
+
+void loop()
+{
+  static auto printTime = millis();
+
+  // Update function should be continuously polled
+  BHY2.update();
+
+  if (millis() - printTime >= 1000) {
+    printTime = millis();
+
+    static float rate;
+    static uint32_t latency;
+
+    accel.readConfiguration(&rate, &latency);
+    Serial.println(String("acceleration configuration - rate: ") + rate + String("Hz - latency: ") + latency + String("ms"));
+
+    gyro.readConfiguration(&rate, &latency);
+    Serial.println(String("gyro configuration - rate: ") + rate + String(" - latency: ") + latency + String("ms"));
+
+    temp.readConfiguration(&rate, &latency);
+    Serial.println(String("temperature configuration - rate: ") + rate + String(" - latency: ") + latency + String("ms"));
+
+    gas.readConfiguration(&rate, &latency);
+    Serial.println(String("gas configuration - rate: ") + rate + String(" - latency: ") + latency + String("ms"));
+
+    rotation.readConfiguration(&rate, &latency);
+    Serial.println(String("rotation configuration - rate: ") + rate + String(" - latency: ") + latency + String("ms"));
+    Serial.println();
+  }
+}

--- a/Arduino_BHY2/src/BoschSensortec.cpp
+++ b/Arduino_BHY2/src/BoschSensortec.cpp
@@ -116,6 +116,21 @@ void BoschSensortec::configureSensor(SensorConfigurationPacket& config)
   }
 }
 
+void BoschSensortec::readSensorConfiguration(SensorConfigurationPacket* config)
+{
+  struct bhy2_virt_sensor_conf virt_sensor_conf;
+
+  auto ret = bhy2_get_virt_sensor_cfg(config->sensorId, &virt_sensor_conf, &_bhy2);
+  if (_debug) _debug->println(get_api_error(ret));
+  if (ret == BHY2_OK) {
+    _acknowledgment = SensorAck;
+  } else {
+    _acknowledgment = SensorNack;
+  }
+  config->sampleRate = virt_sensor_conf.sample_rate;
+  config->latency = virt_sensor_conf.latency;
+}
+
 uint8_t BoschSensortec::availableSensorData()
 {
   return _sensorQueue.size();

--- a/Arduino_BHY2/src/BoschSensortec.h
+++ b/Arduino_BHY2/src/BoschSensortec.h
@@ -35,6 +35,7 @@ public:
   bool begin(); 
   void update();
   void configureSensor(SensorConfigurationPacket& config);
+  void readSensorConfiguration(SensorConfigurationPacket* config);
 
   void printSensors();
   bool hasSensor(uint8_t sensorId);

--- a/Arduino_BHY2/src/sensors/SensorClass.cpp
+++ b/Arduino_BHY2/src/sensors/SensorClass.cpp
@@ -49,6 +49,17 @@ void SensorClass::configure(float rate, uint32_t latency)
 
 }
 
+void SensorClass::readConfiguration(float *rate, uint32_t *latency)
+{
+  SensorConfigurationPacket config;
+  
+  config.sensorId = _id;
+  sensortec.readSensorConfiguration(&config);
+
+  *rate = config.sampleRate;
+  *latency = config.latency;
+}
+
 void SensorClass::end()
 {
   configure(0, 0);

--- a/Arduino_BHY2/src/sensors/SensorClass.h
+++ b/Arduino_BHY2/src/sensors/SensorClass.h
@@ -21,6 +21,7 @@ public:
    */
   bool begin(float rate = 1000, uint32_t latency = 1);
   void configure(float rate, uint32_t latency);
+  void readConfiguration(float* rate, uint32_t* latency);
   void end();
 
   virtual void setData(SensorDataPacket &data) = 0;


### PR DESCRIPTION
### Description

Add methods for reading current and actual sensor configuration, namely `rate` and `latency`.

This PR is needed because default values (e.g. `rate = 1000`) are above the supported ranges for sensors; thus, the virtual sensor gets properly configured with automatic values. A specific call is used to retrieve the actual configuration.

Possible duplicate of #47

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add an 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

