### PR TITLE
Remove device name from device filter to avoid caching issues

### DIFF
--- a/tools/bhy-controller/src/static/sensor.html
+++ b/tools/bhy-controller/src/static/sensor.html
@@ -105,7 +105,6 @@ document.getElementById('sensorId').value = '10';
 document.getElementById('rate').value = '0';
 document.getElementById('latency').value = '0';
 
-const deviceName = 'NICLA'
 const sensorServiceUuid = '34c2e3bb-34aa-11eb-adc1-0242ac120002';
 const sensorConfigCharacteristicUuid = '34c2e3bd-34aa-11eb-adc1-0242ac120002';
 const sensorDataCharacteristicUuid = '34c2e3bc-34aa-11eb-adc1-0242ac120002';
@@ -226,8 +225,7 @@ function isWebBluetoothEnabled() {
 
 function getDeviceInfo() {
   let options = {
-    filters: [{ name: deviceName}],
-    optionalServices: [sensorServiceUuid]
+    filters: [{ services: [sensorServiceUuid]}]    
   };
   console.log('Requesting BLE device info...');
   return navigator.bluetooth.requestDevice(options).then(device => {


### PR DESCRIPTION
### Description

Any Nicla Sense that was previously connected to my computer over WebBLE had its name cached. Even when uploading the App sketch it wasn't updated. The webapp used the device name as a filter and hence my devices never showed up. This PR removes the device name from the filter only using the service ID. This avoids these kind of caching issues.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

