### PR TITLE
[AE-60] Remove color comments, ledBlink function intensity

### DIFF
--- a/bootloader/examples/Blink_Unisense/Blink_Unisense.ino
+++ b/bootloader/examples/Blink_Unisense/Blink_Unisense.ino
@@ -48,21 +48,31 @@ void setup() {
 }
 
 void loop() {
-  ledBlink(green, 1000);    //blue
+  //cycle through LED colour configurations
+  ledBlink(green, 1000);    
   delay(1000);
-  ledBlink(blue, 1000);     //green
+  ledBlink(blue, 1000);     
   delay(1000);
   ledBlink(red, 1000);
   delay(1000);
   ledBlink(cyan, 1000);
   delay(1000);
-  ledBlink(magenta, 1000);    //yellow
+  ledBlink(magenta, 1000);    
   delay(1000);
-  ledBlink(yellow, 1000);     //magenta
+  ledBlink(yellow, 1000);     
   delay(1000);
 }
 
+/**
+ * Blink a given color for a set duration in milliseconds. 
+*/
 void ledBlink(uint8_t color, uint32_t duration)
+/**
+ * Intensity is defined in 256 levels according to table 7 of the IS31FL3194 datasheet:
+ * 0x00 -> 0
+ * 0x20 -> I_max * (2^7) / 256 = I_max  * 1/2
+ * 0xFF -> I_max * (2^7 + 2^6 + 2^5 + 2^4 + 2^3 + 2^2 + 2^1 + 2^0) / 255 ~= I_max
+*/
 {
   if(color == green) {
   _out1 = 0x00;


### PR DESCRIPTION
### Description

- Remove inaccurate comments for LED color
- Explain LED intensity levels

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

