### PR TITLE
Fix license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Check Arduino status](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/check-arduino.yml)
 [![Compile Examples status](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/compile-examples.yml)
-[![Check License status](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/check-license.
+[![Check License status](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/check-license.yml)
 [![Spell Check status](https://github.com/arduino/nicla-sense-me-fw/actions/workflows/spell-check-task.yml/badge.svg)](github.com/arduino/nicla-sense-me-fw/actions/workflows/spell-check-task.yml)
 
 This repo contains everything needed to program Nicla Sense ME and to control it from another device. Further documentation can be found on the [Arduino Docs website](https://docs.arduino.cc/hardware/nicla-sense-me).


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

The two characters at the end of the license badge link were eaten up. Restoring to the former glory. 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

