### PR TITLE
fix bug in parseActivity api with wrong parameter type

### DIFF
--- a/Arduino_BHY2Host/src/sensors/DataParser.cpp
+++ b/Arduino_BHY2Host/src/sensors/DataParser.cpp
@@ -84,6 +84,6 @@ void DataParser::parseData(SensorDataPacket& data, float& value, float scaleFact
 
 }
 
-void DataParser::parseActivity(SensorDataPacket& data, uint16_t value) {
+void DataParser::parseActivity(SensorDataPacket& data, uint16_t& value) {
   value = data.getUint16(0);
 }

--- a/Arduino_BHY2Host/src/sensors/DataParser.h
+++ b/Arduino_BHY2Host/src/sensors/DataParser.h
@@ -78,7 +78,7 @@ public:
   static void parseBSEC(SensorLongDataPacket& data, DataBSEC& vector);
   static void parseBSECLegacy(SensorLongDataPacket& data, DataBSEC& vector);
   static void parseData(SensorDataPacket& data, float& value, float scaleFactor, SensorPayload format);
-  static void parseActivity(SensorDataPacket& data, uint16_t value);
+  static void parseActivity(SensorDataPacket& data, uint16_t& value);
 };
 
 #endif


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
fix bug in parseActivity api with wrong parameter type

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

