### PR TITLE
Expand CI coverage to four examples from the Nicla Sense ME User Manual

### DIFF
--- a/Arduino_BHY2/examples/AccelGyro/AccelGyro.ino
+++ b/Arduino_BHY2/examples/AccelGyro/AccelGyro.ino
@@ -1,0 +1,60 @@
+/*
+ * This example shows how to use the access the IMU data and plot it in real time.
+ * 
+ * Every 50 milliseconds, this sketch will send the x,y and z accelerometer (SensorID 4) and
+ * gyroscope (SensorID 22) values over serial from the BHI260AP six axis IMU.
+ * These six values are visually displayed with the Serial Plotter in the Arduino IDE. 
+ * 
+ * Instructions:
+ * 1. Upload this sketch to your Nicla Sense ME board.
+ * 2. Open the Serial Plotter at a baud rate of 115200.
+ * 3. The three axis values for both the accelerometer and gyroscope will be printed to the Serial Plotter.
+ * 4. Optionally, you can change the visability of each data by clicking on the legend.
+ * 
+ * Initial author: @mcmchris
+ */
+
+#include "Arduino_BHY2.h"
+
+SensorXYZ accel(SENSOR_ID_ACC);
+SensorXYZ gyro(SENSOR_ID_GYRO);
+
+
+void setup() {
+  Serial.begin(115200);
+  BHY2.begin();
+  accel.begin();
+  gyro.begin();
+}
+
+void loop() {
+  static auto printTime = millis();
+
+  // Update function should be continuously polled
+  BHY2.update();
+
+  if (millis() - printTime >= 50) {
+    printTime = millis();
+
+    // Accelerometer values
+    Serial.print("acc_X:");
+    Serial.print(accel.x());
+    Serial.print(",");
+    Serial.print("acc_Y:");
+    Serial.print(accel.y());
+    Serial.print(",");
+    Serial.print("acc_Z:");
+    Serial.print(accel.z());
+    Serial.print(",");
+
+    // Gyroscope values
+    Serial.print("gyro_X:");
+    Serial.print(gyro.x());
+    Serial.print(",");
+    Serial.print("gyro_Y:");
+    Serial.print(gyro.y());
+    Serial.print(",");
+    Serial.print("gyro_Z:");
+    Serial.println(gyro.z());
+  }
+}

--- a/Arduino_BHY2/examples/AccelGyro/AccelGyro.ino
+++ b/Arduino_BHY2/examples/AccelGyro/AccelGyro.ino
@@ -9,7 +9,7 @@
  * 1. Upload this sketch to your Nicla Sense ME board.
  * 2. Open the Serial Plotter at a baud rate of 115200.
  * 3. The three axis values for both the accelerometer and gyroscope will be printed to the Serial Plotter.
- * 4. Optionally, you can change the visability of each data by clicking on the legend.
+ * 4. Optionally, you can change the visibility of each data by clicking on the legend.
  * 
  * Initial author: @mcmchris
  */

--- a/Arduino_BHY2/examples/ActivityRecognition/ActivityRecognition.ino
+++ b/Arduino_BHY2/examples/ActivityRecognition/ActivityRecognition.ino
@@ -1,0 +1,37 @@
+/*
+ * This example shows how to use the Nicla Sense ME library to detect activity and send it over serial.
+ * 
+ * Every 1 second, this sketch will send the latest activity detected via the BHI260AP sensor to the serial port.
+ * Without any additional training, it is possible to detect Still, Walking, Running and Tilting activities
+ * A full description of supported activities is avaliable in Table 93 of the BHI260AP datasheet.
+ * 
+ * Instructions:
+ * 1. Upload this sketch to your Nicla Sense ME board.
+ * 2. Open the Serial Monitor at a baud rate of 115200.
+ * 3. Observe the detected activity, by moving the Nicla Sense ME board.
+ * 
+ * Initial author: @mcmchris
+ */
+
+#include "Arduino_BHY2.h"
+
+SensorActivity active(SENSOR_ID_AR);
+
+unsigned long previousMillis = 0;  // will store last time the sensor was updated
+const long interval = 1000;
+
+
+void setup() {
+  Serial.begin(115200);
+  BHY2.begin();
+  active.begin();
+}
+
+void loop() {
+  BHY2.update();
+  unsigned long currentMillis = millis();
+  if (currentMillis - previousMillis >= interval) {
+    previousMillis = currentMillis;
+    Serial.println(String("Activity info: ") + active.toString());
+  }
+}

--- a/Arduino_BHY2/examples/ActivityRecognition/ActivityRecognition.ino
+++ b/Arduino_BHY2/examples/ActivityRecognition/ActivityRecognition.ino
@@ -3,7 +3,7 @@
  * 
  * Every 1 second, this sketch will send the latest activity detected via the BHI260AP sensor to the serial port.
  * Without any additional training, it is possible to detect Still, Walking, Running and Tilting activities
- * A full description of supported activities is avaliable in Table 93 of the BHI260AP datasheet.
+ * A full description of supported activities is available in Table 93 of the BHI260AP datasheet.
  * 
  * Instructions:
  * 1. Upload this sketch to your Nicla Sense ME board.

--- a/Arduino_BHY2/examples/Magnetometer/Magnetometer.ino
+++ b/Arduino_BHY2/examples/Magnetometer/Magnetometer.ino
@@ -2,7 +2,7 @@
  * This example shows how to use the access the magnetometer data and send it over serial.
  * 
  * Every 1 second, this sketch will send the heading of the magnetometer over serial.
- * by calculating the arctangent between the x and y axis and multiplied in a convertion
+ * by calculating the arctangent between the x and y axis and multiplied in a conversion
  * factor to convert the headings from radians to degrees.
  * 
  * Instructions:

--- a/Arduino_BHY2/examples/Magnetometer/Magnetometer.ino
+++ b/Arduino_BHY2/examples/Magnetometer/Magnetometer.ino
@@ -1,0 +1,41 @@
+/*
+ * This example shows how to use the access the magnetometer data and send it over serial.
+ * 
+ * Every 1 second, this sketch will send the heading of the magnetometer over serial.
+ * SensorID 22 (SENSOR_ID_MAG) is read with the SensorXYS class. The heading is calculated
+ * by calculating the arctangent between the x and y axis and multiplied in a convertion
+ * factor to convert the headings from radians to degrees.
+ * 
+ * Instructions:
+ * 1. Upload this sketch to your Nicla Sense ME board.
+ * 2. Open the Serial Monitor at a baud rate of 115200.
+ * 3. The heading of the magnetometer will be printed to the serial monitor.
+ * 
+ * Initial author: @mcmchris
+ */
+
+#include "Arduino_BHY2.h"
+#include "Math.h"
+
+SensorXYZ magnetometer(SENSOR_ID_MAG);
+
+float heading = 0;
+unsigned long previousMillis = 0;  // will store last time the sensor was updated
+const long interval = 1000;
+
+void setup() {
+  Serial.begin(115200);
+  BHY2.begin();
+  magnetometer.begin();
+
+}
+
+void loop() {
+  BHY2.update();
+  unsigned long currentMillis = millis();
+  if (currentMillis - previousMillis >= interval) {
+    previousMillis = currentMillis;
+    heading = round(atan2(magnetometer.x(), magnetometer.y()) * 180.0 / PI);
+    Serial.println(String(heading) + "º");
+  }
+}

--- a/Arduino_BHY2/examples/Magnetometer/Magnetometer.ino
+++ b/Arduino_BHY2/examples/Magnetometer/Magnetometer.ino
@@ -2,7 +2,6 @@
  * This example shows how to use the access the magnetometer data and send it over serial.
  * 
  * Every 1 second, this sketch will send the heading of the magnetometer over serial.
- * SensorID 22 (SENSOR_ID_MAG) is read with the SensorXYS class. The heading is calculated
  * by calculating the arctangent between the x and y axis and multiplied in a convertion
  * factor to convert the headings from radians to degrees.
  * 
@@ -27,7 +26,6 @@ void setup() {
   Serial.begin(115200);
   BHY2.begin();
   magnetometer.begin();
-
 }
 
 void loop() {

--- a/Arduino_BHY2/examples/Pressure/Pressure.ino
+++ b/Arduino_BHY2/examples/Pressure/Pressure.ino
@@ -1,0 +1,36 @@
+/*
+ * This example shows how to use the access the pressure data and send it over serial.
+ * 
+ * Every 1 second, this sketch will send the pressure in hPa over serial.
+ * SensorID 129 (SENSOR_ID_BARO) is read with the Sensor class from the BMP390.
+ * 
+ * Instructions:
+ * 1. Upload this sketch to your Nicla Sense ME board.
+ * 2. Open the Serial Monitor at a baud rate of 9600.
+ * 3. The pressure will be printed to the serial monitor.
+ * 
+ * Initial author: @mcmchris
+ */
+
+#include "Arduino_BHY2.h"
+
+
+unsigned long previousMillis = 0;  // will store last time the sensor was updated
+const long interval = 1000;
+
+Sensor pressure(SENSOR_ID_BARO);
+
+void setup() {
+  Serial.begin(9600);
+  BHY2.begin();
+  pressure.begin();
+}
+
+void loop() {
+  BHY2.update();
+  unsigned long currentMillis = millis();
+  if (currentMillis - previousMillis >= interval) {
+    previousMillis = currentMillis;
+    Serial.println(String(pressure.value()) + " hPa");
+  }
+}

--- a/Arduino_BHY2/examples/Pressure/Pressure.ino
+++ b/Arduino_BHY2/examples/Pressure/Pressure.ino
@@ -6,7 +6,7 @@
  * 
  * Instructions:
  * 1. Upload this sketch to your Nicla Sense ME board.
- * 2. Open the Serial Monitor at a baud rate of 9600.
+ * 2. Open the Serial Monitor at a baud rate of 115200.
  * 3. The pressure will be printed to the serial monitor.
  * 
  * Initial author: @mcmchris


### PR DESCRIPTION
# What this PR solves

This PR adds four new examples to the Arduino_BHY2 library extracted from the Nicla Sense ME User Manual, initially developed by @mcmchris.
- ✨ Adds new `ActivityRecognition`, `Magnetometer`, `AccelGyro` and `Pressure` sketches
- ✍️ All newly added sketches, include a header comment allow for standalone use
- 🧹 Removed unnecessary `#include "Arduino.h"` and `#include "Nicla_System.h"` (See note A).
- 🍃 Remove redundant definitions of the communication configuration in `BHY2.begin(NICLA_I2C)` (See note B)
- 😄 Users can conveniently access the selected sketches directly from the IDE
- 🤖 The examples are covered by the CI checks. This will ensure that **regressions in the User Manual sketches code are detected**.

cc @mcmchris , @jcarolinares

---
## Note A: Includes
When the Arduino_BHY2 library is included as part of the sketch, both the `Arduino.h` as well as the `Nicla_System.h` libraries are included by extension. 
- https://github.com/arduino/nicla-sense-me-fw/blob/fb6b5e924470fa52473781c0babac65fd171d862/Arduino_BHY2/src/Arduino_BHY2.cpp#L1-L11

## Note B: Redundant definitions
When the `BHY2.begin()` method is called, there are four configurations for the `NiclaConfig` enumerator that can be called.
https://github.com/arduino/nicla-sense-me-fw/blob/fb6b5e924470fa52473781c0babac65fd171d862/Arduino_BHY2/src/Arduino_BHY2.h#L31-L42

The `NICLA_BLE_AND_I2C` is set by default, which covers functionality of the `NICLA_I2C` enumerator. This behavior is documented in the source code. Thus, there is no need to define `BHY2.begin(NICLA_I2C)`. 
https://github.com/arduino/nicla-sense-me-fw/blob/fb6b5e924470fa52473781c0babac65fd171d862/Arduino_BHY2/src/Arduino_BHY2.h#L82-L96 
`BHY2.begin()` is enough, unless the user wants to access more advanced features.

