### PR TITLE
CI fixes for ArduinoBHY2Host

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -147,6 +147,7 @@ jobs:
             # Install these libraries in addition to the universal ones
             arduinoiotcloud-libraries: |
               - name: ArduinoIoTCloud
+              - name: Arduino_Cellular
             # Compile these sketches in addition to the universal ones
             arduinoiotcloud-sketch-paths: |
               - Arduino_BHY2Host/examples/Nicla_IoT_Bridge
@@ -169,6 +170,7 @@ jobs:
             # Install these libraries
             blebridge-libraries: |
               - name: ArduinoIoTCloud
+              - name: Arduino_Cellular
             # Compile these sketches
             blebridge-sketch-paths: |
               - Arduino_BHY2Host/examples/Portenta_BLE_Bridge

--- a/Arduino_BHY2/examples/Magnetometer/Magnetometer.ino
+++ b/Arduino_BHY2/examples/Magnetometer/Magnetometer.ino
@@ -14,7 +14,7 @@
  */
 
 #include "Arduino_BHY2.h"
-#include "Math.h"
+#include "math.h"
 
 SensorXYZ magnetometer(SENSOR_ID_MAG);
 

--- a/Arduino_BHY2Host/library.properties
+++ b/Arduino_BHY2Host/library.properties
@@ -7,5 +7,5 @@ paragraph=Provides the APIs for a host board to interact with Nicla Sense ME boa
 category=Communication
 url=https://github.com/arduino-libraries/Arduino_BHY2Host
 architectures=samd,mbed
-depends= ArduinoIoTCloud, Arduino_ConnectionHandler, Arduino_Cellular
+depends= ArduinoIoTCloud, Arduino_ConnectionHandler, Arduino_Cellular, ArduinoCellular
 includes=Arduino_BHY2Host.h

--- a/Arduino_BHY2Host/library.properties
+++ b/Arduino_BHY2Host/library.properties
@@ -7,5 +7,5 @@ paragraph=Provides the APIs for a host board to interact with Nicla Sense ME boa
 category=Communication
 url=https://github.com/arduino-libraries/Arduino_BHY2Host
 architectures=samd,mbed
-depends= ArduinoIoTCloud, Arduino_ConnectionHandler, Arduino_Cellular, ArduinoCellular
+depends= ArduinoIoTCloud, Arduino_ConnectionHandler, Arduino_Cellular
 includes=Arduino_BHY2Host.h

--- a/Arduino_BHY2Host/library.properties
+++ b/Arduino_BHY2Host/library.properties
@@ -7,4 +7,5 @@ paragraph=Provides the APIs for a host board to interact with Nicla Sense ME boa
 category=Communication
 url=https://github.com/arduino-libraries/Arduino_BHY2Host
 architectures=samd,mbed
+depends= ArduinoIoTCloud, Arduino_ConnectionHandler
 includes=Arduino_BHY2Host.h

--- a/Arduino_BHY2Host/library.properties
+++ b/Arduino_BHY2Host/library.properties
@@ -7,5 +7,5 @@ paragraph=Provides the APIs for a host board to interact with Nicla Sense ME boa
 category=Communication
 url=https://github.com/arduino-libraries/Arduino_BHY2Host
 architectures=samd,mbed
-depends= ArduinoIoTCloud, Arduino_ConnectionHandler
+depends= ArduinoIoTCloud, Arduino_ConnectionHandler, Arduino_Cellular
 includes=Arduino_BHY2Host.h


### PR DESCRIPTION
### Description

This PR attempts to resolve CI reporting failures in the Compile Examples workflow with:
- `Math.h` not accepted as included library (see https://github.com/arduino/compile-sketches/issues/270)
- Nicla_IoT_Bridge.ino and Portenta_BLE_Bridge.ino sketches compile https://github.com/arduino/nicla-sense-me-fw/issues/141 

Currently, **the first item is resolved**. However, the two sketches (Nicla_IoT_Bridge.ino and Portenta_BLE_Bridge.ino) still do not compile since the `ArduinoCellular.h` library is not found.

```
  /home/runner/Arduino/libraries/Arduino_ConnectionHandler/src/Arduino_ConnectionHandler.h:60:12: fatal error: Arduino_Cellular.h: No such file or directory
     #include <Arduino_Cellular.h>
              ^~~~~~~~~~~~~~~~~~~~
  compilation terminated.
```

See https://github.com/arduino/nicla-sense-me-fw/issues/141#issuecomment-2260670257 for more details


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

