### PR TITLE
github: Use IAM Roles to push files on AWS S3

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -8,6 +8,7 @@ env:
   DIST_DIR: tools/bhy-controller/src/dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /unisense/tools/bhy-controller/
+  AWS_REGION: "us-east-1"
   ARTIFACT_NAME: dist
 
 on:
@@ -170,9 +171,11 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
+    environment: production
     needs: notarize-macos
     permissions:
       contents: write
+      id-token: write # This is required for requesting the JWT
 
     steps:
       - name: Download artifact
@@ -215,12 +218,12 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}


### PR DESCRIPTION
For security reasons long lived credentials are not considered secure. To overcome this issue we can configure Github Workflows to use AWS OpenID Connect instead: For further details: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect